### PR TITLE
return 'name' property instead of 'pluginName'

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -39,7 +39,7 @@ export default ({
   relative = defaultOptions.relative,
   transformOutputPath,
 } = defaultOptions) => ({
-  pluginName,
+  name: pluginName,
   options(conf) {
     // flat to enable input to be a string or an array
     // separate globs inputs string from others to enable input to be a mixed array too


### PR DESCRIPTION
return 'name' property instead of 'pluginName' to correctly implement the rollup Plugin interface.